### PR TITLE
git-todo: Too many levels of symbolic links

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,1 @@
-ln -sf ./git-todo /usr/local/bin/git-todo;
+ln -sf ${PWD}/git-todo /usr/local/bin/git-todo;


### PR DESCRIPTION
```
➜  git-todo
zsh: too many levels of symbolic links: git-todo
```

https://unix.stackexchange.com/a/180532